### PR TITLE
fix WP user meta query

### DIFF
--- a/WPTrezorPlugin.php
+++ b/WPTrezorPlugin.php
@@ -185,9 +185,9 @@ class WPTrezorPlugin {
         if ($this->verify($challenge_hidden, $challenge_visual, $public_key, $signature, $version)) {
 
             $args = array(
-                'key'     => 'trezor_publickey',
-                'value'   => $public_key,
-                'compare' => '='
+                'meta_key'     => 'trezor_publickey',
+                'meta_value'   => $public_key,
+                'meta_compare' => '='
             );
 
             $users = new WP_User_Query($args);


### PR DESCRIPTION
WP_User_Query() query arguments were missing the prefix "meta_" so the query result contained all users.

https://codex.wordpress.org/Class_Reference/WP_User_Query#Custom_Field_Parameters